### PR TITLE
feat(subman): remove link to console.redhat.com AND fix: Do not use insights-details.json

### DIFF
--- a/src/insights.jsx
+++ b/src/insights.jsx
@@ -519,14 +519,6 @@ export class InsightsStatus extends React.Component {
             const warn = ((insights_service.state === "failed" || (insights_service.state === "starting" && insights_service.details.Result !== "success")) &&
                         insights_service.unit.ActiveExitTimestamp &&
                         insights_service.unit.ActiveExitTimestamp / 1e6 > last_upload_monitor.timestamp);
-
-            let url;
-            try {
-                url = "https://console.redhat.com/insights/inventory/" + this.state.host_details.results[0].id;
-            } catch (err) {
-                url = "https://console.redhat.com/insights";
-            }
-
             let text;
             try {
                 const n_rule_hits = this.state.insights_details.length;
@@ -567,31 +559,37 @@ export class InsightsStatus extends React.Component {
                     }
                 }
             } catch (err) {
-                text = _("View your Insights results");
+                text = null;
             }
 
-            status = (
-                <Stack hasGutter>
-                    <StackItem>
-                        <Button isInline
-                            variant="link"
-                            icon={warn ? <Icon status="warning"><WarningTriangleIcon /></Icon> : null}
-                            onClick={left(show_status_dialog)}
-                        >
-                            {_("Connected to Insights")}
-                        </Button>
-                    </StackItem>
-                    <StackItem>
-                        <Button isInline
-                            variant="link" component="a" href={url}
-                            target="_blank" rel="noopener noreferrer"
-                            icon={<ExternalLinkAltIcon />}
-                        >
+            if (text) {
+                status = (
+                    <Stack hasGutter>
+                        <StackItem>
+                            <Button isInline
+                                variant="link"
+                                icon={warn ? <Icon status="warning"><WarningTriangleIcon /></Icon> : null}
+                                onClick={left(show_status_dialog)}
+                            >
+                                {_("Connected to Insights")}
+                            </Button>
+                        </StackItem>
+                        <StackItem>
                             { text }
-                        </Button>
-                    </StackItem>
-                </Stack>
-            );
+                        </StackItem>
+                    </Stack>
+                );
+            } else {
+                status = (
+                    <Button isInline
+                        variant="link"
+                        icon={warn ? <Icon status="warning"><WarningTriangleIcon /></Icon> : null}
+                        onClick={left(show_status_dialog)}
+                    >
+                        {_("Connected to Insights")}
+                    </Button>
+                );
+            }
         } else {
             status = <Button variant="link" isInline onClick={left(show_connect_dialog)}>{_("Not connected")}</Button>;
         }

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -285,7 +285,6 @@ class TestSubscriptions(SubscriptionsCase):
         with b.wait_timeout(600):
             b.wait_not_present(".pf-v6-c-modal-box")
 
-        b.wait_visible("#overview a[href='https://console.redhat.com/insights/inventory/123-nice-id']")
         b.wait_visible("#overview a:contains('3 hits, including important')")
 
         # test system purpose

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -285,8 +285,6 @@ class TestSubscriptions(SubscriptionsCase):
         with b.wait_timeout(600):
             b.wait_not_present(".pf-v6-c-modal-box")
 
-        b.wait_visible("#overview a:contains('3 hits, including important')")
-
         # test system purpose
         m.execute(
             ["subscription-manager", "syspurpose", "role", "--set", "Red Hat Enterprise Linux Workstation"]


### PR DESCRIPTION
This PR was previously #100 and I cherry-picked commit from #97 so there is no need for 2 QE verifications.

---
#100 
* Card ID: CCT-1511

* I removed links to console.redhat.com as there is no guarantee of the system registering to console.redhat.com with the introduction of Insights on-prem.
---
#97 
* Card ID: CCT-1082
* Card ID: CCT-1421

* We decided to remove reading of /var/lib/insights/insights-details.json file, because insights-client will stop generating this file completly in the future.
* The link on details will remain
* Fixed integration tests